### PR TITLE
Updated README and travis build to only use `go get`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 go_import_path: github.com/thourfor/stocktopus
 
 install:
-- git clone https://github.com/thorfour/stocktopus.git
-- go get -t -d ./...
+- go get -t -d github.com/thorfour/stocktopus/...
 
 language: go
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,7 @@ Simple Slack bot that posts stock prices. It can be build as an RTM Slack bot, o
 
 ## Download
 
-`git clone https://github.com/thorfour/stocktopus.git`
-
-Run in the stocktopus directory to download dependencies 
-
-`go get -t -d ./...`
+`go get -t -d github.com/thorfour/stocktopus/...`
 
 ## Build
 ### AWS Lambda:


### PR DESCRIPTION
move back to using go get to download stocktopus