### PR TITLE
Added kick for gcp builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,7 @@ gcp: setup
 	mkdir -p ./bin/gcp/auth
 	CGO_ENABLED=0 GOOS=linux go build -o ./bin/gcp/auth/$(AUTH_NAME) ./cmd/oauth/
 	zip -j ./bin/gcp/auth/authtopus.zip ./build/authtopus/gcp/* ./bin/auth/*
+	mkdir -p ./bin/gcp/kick
+	zip -j ./bin/gcp/kick/kick.zip ./build/serverless/gcp/kick/*
 clean:
 	rm -r ./bin

--- a/build/serverless/gcp/kick/index.js
+++ b/build/serverless/gcp/kick/index.js
@@ -1,0 +1,22 @@
+var nextFuncURL = "STOCKTOPUS ENDPOINT" 
+var request = require('request')
+var headers = {
+    'User-Agent': 'Super Agent/0.0.1',
+    'Content-Type': 'application/json',
+}
+
+exports.handler = function(req, res) {
+
+    // Immediately send OK response
+    res.status(200).end();
+
+    var options = {
+        url: nextFuncURL,
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(req.body)
+    }
+
+    // Pass request to next cloud function
+    request(options);
+};

--- a/build/serverless/gcp/kick/package.json
+++ b/build/serverless/gcp/kick/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "sample-http",
+    "version": "0.0.1",
+    "dependencies": {
+        "request": "^2.81.0"
+    }
+}


### PR DESCRIPTION
Google functions were often timing out. Instead have the kick fucntion
respond immmediately, and start the stocktopus function to respond later

Issue #10 